### PR TITLE
Upgrade to deegree 3.5.10

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -27,11 +27,11 @@ jobs:
           context: ./3.5
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/lat-lon/deegree3-containers:3.5.9,ghcr.io/lat-lon/deegree3-containers:3.5,ghcr.io/lat-lon/deegree3-containers:latest
+          tags: ghcr.io/lat-lon/deegree3-containers:3.5.10,ghcr.io/lat-lon/deegree3-containers:3.5,ghcr.io/lat-lon/deegree3-containers:latest
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.29.0
         with:
-          image-ref: 'ghcr.io/lat-lon/deegree3-containers:3.5.9'
+          image-ref: 'ghcr.io/lat-lon/deegree3-containers:3.5.10'
           format: 'sarif'
           severity: 'CRITICAL'
           output: 'trivy-results.sarif'

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -22,16 +22,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push v3.5
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./3.5
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/lat-lon/deegree3-containers:3.5.8,ghcr.io/lat-lon/deegree3-containers:3.5,ghcr.io/lat-lon/deegree3-containers:latest
+          tags: ghcr.io/lat-lon/deegree3-containers:3.5.9,ghcr.io/lat-lon/deegree3-containers:3.5,ghcr.io/lat-lon/deegree3-containers:latest
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.29.0
         with:
-          image-ref: 'ghcr.io/lat-lon/deegree3-containers:3.5.8'
+          image-ref: 'ghcr.io/lat-lon/deegree3-containers:3.5.9'
           format: 'sarif'
           severity: 'CRITICAL'
           output: 'trivy-results.sarif'

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/tomcat:9.0.93-debian-12-r1
 
 # set deegree version
-ARG DEEGREE_VERSION=3.5.8
+ARG DEEGREE_VERSION=3.5.9
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VCS_URL

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/tomcat:9.0.93-debian-12-r1
 
 # set deegree version
-ARG DEEGREE_VERSION=3.5.9
+ARG DEEGREE_VERSION=3.5.10
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VCS_URL

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Supported tags and respective `Dockerfile` links
 
-- deegree 3.5.x (JDK 17/Tomcat 9): `3.5.8`, `3.5`, `latest` (deprecated tags: `3.5.6`) - [Dockerfile](https://github.com/lat-lon/deegree3-containers/blob/main/3.5/Dockerfile)
+- deegree 3.5.x (JDK 17/Tomcat 9): `3.5.10`, `3.5`, `latest` (deprecated tags: `3.5.8`, `3.5.6`) - [Dockerfile](https://github.com/lat-lon/deegree3-containers/blob/main/3.5/Dockerfile)
 
 # Quick reference
 


### PR DESCRIPTION
Upgrade deegree to latest bugfix version [3.5.10](https://github.com/deegree/deegree3/releases/tag/deegree-3.5.10).