### PR TITLE
Upgrade base image to bitnami/tomcat:10.1-debian-12

### DIFF
--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -1,7 +1,19 @@
-FROM bitnami/tomcat:9.0-debian-12
+FROM bitnami/tomcat:10.1-debian-12 AS builder
 
-# set deegree version
 ARG DEEGREE_VERSION=3.5.11
+ARG TC_MIG_VERSION=1.0.9
+
+USER root
+
+RUN apt-get update && apt-get -y install curl \
+    && mkdir -p /build_deegree \
+    && cd /build_deegree \
+    && curl https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/${DEEGREE_VERSION}/deegree-webservices-${DEEGREE_VERSION}.war -o /build_deegree/deegree-webservices-original.war \
+    && curl -o jakartaee-migration-${TC_MIG_VERSION}-shaded.jar https://dlcdn.apache.org/tomcat/jakartaee-migration/v${TC_MIG_VERSION}/binaries/jakartaee-migration-${TC_MIG_VERSION}-shaded.jar \
+    && java -jar jakartaee-migration-${TC_MIG_VERSION}-shaded.jar /build_deegree/deegree-webservices-original.war /build_deegree/deegree-webservices.war
+
+FROM bitnami/tomcat:10.1-debian-12 AS runner
+
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VCS_URL
@@ -16,21 +28,20 @@ ENV TOMCAT_PASSWORD=deegree
 ENV LOG_DIR=/deegree/logs
 ENV DEEGREE_WORKSPACE_ROOT=/deegree/workspaces
 ENV TOMCAT_EXTRA_JAVA_OPTS="-Djavax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactoryImpl -Dlog.dir=$LOG_DIR --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/com.sun.imageio.spi=ALL-UNNAMED --add-exports java.desktop/sun.swing=ALL-UNNAMED --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED"
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 USER root
 
 # Reinstall zlib1g with fixed CVE-2023-45853 on trixie: https://security-tracker.debian.org/tracker/CVE-2023-45853
 RUN echo 'deb http://deb.debian.org/debian trixie main' > /etc/apt/sources.list.d/trixie.list \
     && echo $'Package: *\nPin: release n=trixie\nPin-Priority: -10\n\nPackage: zlib1g\nPin: release n=trixie\nPin-Priority: 501' > /etc/apt/preferences.d/trixie.pref \
-    && apt-get update && apt-get -u install zlib1g && apt-get -y install curl fontconfig
+    && apt-get update && apt-get -u install zlib1g && apt-get -y install unzip fontconfig
 
-# download deegree webservices WAR file
-RUN curl https://repo.deegree.org/content/repositories/public/org/deegree/deegree-webservices/${DEEGREE_VERSION}/deegree-webservices-${DEEGREE_VERSION}.war -o /tmp/deegree-webservices.war
+COPY --from=builder /build_deegree/deegree-webservices.war /tmp/deegree-webservices.war
 RUN mkdir /opt/bitnami/tomcat/webapps/$WEB_CONTEXT \
 	&& cd /opt/bitnami/tomcat/webapps/$WEB_CONTEXT \
-	&& jar xf /tmp/deegree-webservices.war \
-	&& rm /tmp/deegree-webservices.war
+    && unzip '/tmp/deegree-webservices.war' \
+    && rm /tmp/deegree-webservices.war
 
 RUN chmod o+w /opt/bitnami/tomcat/bin/setenv.sh \
     && chmod o+w /opt/bitnami/tomcat/logs/ \
@@ -40,4 +51,5 @@ RUN chmod o+w /opt/bitnami/tomcat/bin/setenv.sh \
     && mkdir -p $DEEGREE_WORKSPACE_ROOT && chown 1001 $DEEGREE_WORKSPACE_ROOT \
     && mkdir -p $LOG_DIR && chmod a+w $LOG_DIR
 
+WORKDIR /opt/bitnami/tomcat
 USER 1001


### PR DESCRIPTION
This PR enables the [Apache Migration Tool](https://tomcat.apache.org/download-migration.cgi) to automatically upgrade the deegree webapp to Jakarta EE libs.