### PR TITLE
#348 - upgrade to deegree 3.5.12

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -27,11 +27,11 @@ jobs:
           context: ./3.5
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/lat-lon/deegree3-containers:3.5.11,ghcr.io/lat-lon/deegree3-containers:3.5,ghcr.io/lat-lon/deegree3-containers:latest
+          tags: ghcr.io/lat-lon/deegree3-containers:3.5.12,ghcr.io/lat-lon/deegree3-containers:3.5,ghcr.io/lat-lon/deegree3-containers:latest
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.29.0
         with:
-          image-ref: 'ghcr.io/lat-lon/deegree3-containers:3.5.11'
+          image-ref: 'ghcr.io/lat-lon/deegree3-containers:3.5.12'
           format: 'sarif'
           severity: 'CRITICAL'
           output: 'trivy-results.sarif'

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitnami/tomcat:10.1-debian-12 AS builder
 
-ARG DEEGREE_VERSION=3.5.11
+ARG DEEGREE_VERSION=3.5.12
 ARG TC_MIG_VERSION=1.0.9
 
 USER root

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Supported tags and respective `Dockerfile` links
 
-- deegree 3.5.x (JDK 17/Tomcat 9): `3.5.11`, `3.5`, `latest` (deprecated tags: `3.5.8`, `3.5.6`) - [Dockerfile](https://github.com/lat-lon/deegree3-containers/blob/main/3.5/Dockerfile)
+- deegree 3.5.x (JDK 17/Tomcat 9): `3.5.12`, `3.5`, `latest` (deprecated tags: `3.5.8`, `3.5.6`) - [Dockerfile](https://github.com/lat-lon/deegree3-containers/blob/main/3.5/Dockerfile)
 
 # Quick reference
 


### PR DESCRIPTION
Upgrade to[ deegree 3.5.12](https://github.com/deegree/deegree3/releases/tag/deegree-3.5.12)