### PR TITLE
Fix version of aquasecurity/trivy-action: update to 0.35.0

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -33,7 +33,7 @@ jobs:
             VCS_REF=${{ github.sha }}
             VCS_URL=${{ github.repositoryUrl }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'ghcr.io/lat-lon/deegree3-containers:3.5.17'
           format: 'sarif'
@@ -69,7 +69,7 @@ jobs:
             VCS_REF=${{ github.sha }}
             VCS_URL=${{ github.repositoryUrl }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.1
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'ghcr.io/lat-lon/deegree3-containers:3.6.6'
           format: 'sarif'


### PR DESCRIPTION
Fixes Pipeline: https://github.com/lat-lon/deegree3-containers/actions/runs/23420489096
```
build-3_6
Unable to resolve action `aquasecurity/trivy-action@0.34.1`, unable to find version `0.34.1`
build-3_5
Unable to resolve action `aquasecurity/trivy-action@0.34.1`, unable to find version `0.34.1`
```